### PR TITLE
Fix broken URL

### DIFF
--- a/Formula/krr.rb
+++ b/Formula/krr.rb
@@ -6,7 +6,7 @@ class Krr < Formula
         url "https://github.com/robusta-dev/krr/releases/download/v1.3.2/krr-macos-latest-v1.3.2.zip"
         sha256 "38e7bc7a43e525b03d8fa276f97913ae074cf6adb4c1b313f80d523dd78d147a"
     elsif OS.linux?
-        url "https://github.com/robusta-dev/krr/releases/download/v1.3.2/krr-linux-latest-v1.3.2.zip"
+        url "https://github.com/robusta-dev/krr/releases/download/v1.3.2/krr-ubuntu-latest-v1.3.2.zip"
         sha256 "300f0c38948cea371ebc329a67d1801dc78042989471aa9222f49b7aea442071"
     end
   


### PR DESCRIPTION
The URL is broken: 
```bash
brew install krr

# Output
Error: krr: Failed to download resource "krr"
Failure while executing; `/usr/bin/env /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Linuxbrew/4.0.27\ \(Linux\;\ x86_64\ Ubuntu\ 20.04.6\ LTS\)\ curl/7.68.0 --header Accept-Language:\ en --retry 3 --fail --location --silent --head --request GET https://github.com/robusta-dev/krr/releases/download/v1.3.2/krr-linux-latest-v1.3.2.zip` exited with 22. Here's the output:
curl: (22) The requested URL returned error: 404
```

It should be:

<img width="1430" alt="image" src="https://github.com/robusta-dev/homebrew-krr/assets/40051120/f2a45f8e-9a48-420f-baae-ca05659020f4">
