### PR TITLE
Speedup krr first run

### DIFF
--- a/Formula/krr.rb
+++ b/Formula/krr.rb
@@ -13,6 +13,9 @@ class Krr < Formula
     def install
         libexec.install Dir["*"]
         bin.write_exec_script (libexec/"krr")
+        # our binaries are built with pyinstaller and the first executable run is very slow because it unzips packages
+        # to work around that, we "warm up" the binary here during installation so it is fast when the user runs it for the first time
+        system libexec/"krr", "version"
     end
     
     test do

--- a/Formula/krr.rb
+++ b/Formula/krr.rb
@@ -14,7 +14,8 @@ class Krr < Formula
         libexec.install Dir["*"]
         bin.write_exec_script (libexec/"krr")
         # our binaries are built with pyinstaller and the first executable run is very slow because it unzips packages
-        # to work around that, we "warm up" the binary here during installation so it is fast when the user runs it for the first time
+        # to work around that, we "warm up" the binary here during installation so it is fast when the user runs it for the first timeo
+        ohai "Running 'krr version' to warm up binary and extract compressed python libraries... this can take up to 60 seconds"
         system libexec/"krr", "version"
     end
     


### PR DESCRIPTION
Without this, the first `krr` run hangs for about 60 seconds on my machine before printing output. With this, there is still some delay on the first real run (about 15 seconds) but:

1) subsequent runs are faster
2) it is still much better than without this PR
 
Tested succesfully with `brew install --build-from-source ./Formula/krr.rb`